### PR TITLE
refactor: unified nav (menu.js only), token-driven CSS, professional …

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
-/* TECH MINIMAL REDESIGN 2026 v5 — Fixed & Polished */
+/* TECH MINIMAL REDESIGN 2026 v6 — Token-driven */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
 @import url('https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@700,800,900&display=swap');
 
@@ -6,20 +6,60 @@
    DESIGN TOKENS
    ============================================================ */
 :root {
-  --bg-dark:       #0a0a0c;
-  --bg-card:       rgba(22, 22, 26, 0.7);
-  --accent-blue:   #3b82f6;
-  --accent-orange: #f97316;
-  --accent-green:  #10b981;
-  --accent-gray:   #94a3b8;
-  --text-primary:  #f8fafc;
-  --text-secondary:#94a3b8;
-  --text-muted:    #64748b;
-  --glass-border:  rgba(255, 255, 255, 0.08);
-  --glow-blue:     rgba(59, 130, 246, 0.15);
-  --font-display:  'Cabinet Grotesk', 'Inter', sans-serif;
-  --font-body:     'Inter', -apple-system, sans-serif;
-  --font-mono:     'JetBrains Mono', 'Courier New', monospace;
+  /* Base surfaces */
+  --bg-dark:         #0a0a0c;
+  --bg-card:         rgba(22, 22, 26, 0.70);
+  --bg-card-solid:   #16161a;
+  --bg-nav:          rgba(10, 10, 12, 0.92);
+  --bg-dropdown:     #0f0f14;
+  --bg-terminal-hdr: rgba(0, 0, 0, 0.30);
+  --bg-overlay-dark: rgba(0, 0, 0, 0.30);
+
+  /* Accents */
+  --accent-blue:     #3b82f6;
+  --accent-orange:   #f97316;
+  --accent-green:    #10b981;
+  --accent-gray:     #94a3b8;
+  --accent-red:      #ef4444;
+  --accent-yellow:   #f59e0b;
+
+  /* Accent alpha layers */
+  --accent-blue-10:  rgba(59, 130, 246, 0.10);
+  --accent-blue-07:  rgba(59, 130, 246, 0.07);
+  --accent-blue-06:  rgba(59, 130, 246, 0.06);
+  --accent-blue-20:  rgba(59, 130, 246, 0.20);
+  --accent-blue-30:  rgba(59, 130, 246, 0.30);
+  --accent-blue-50:  rgba(59, 130, 246, 0.50);
+  --accent-green-10: rgba(16, 185, 129, 0.10);
+  --accent-green-20: rgba(16, 185, 129, 0.20);
+  --accent-orange-10:rgba(249, 115, 22, 0.10);
+
+  /* Text */
+  --text-primary:    #f8fafc;
+  --text-secondary:  #94a3b8;
+  --text-muted:      #64748b;
+  --text-white:      #ffffff;
+
+  /* Borders & dividers */
+  --glass-border:    rgba(255, 255, 255, 0.08);
+  --border-surface:  rgba(255, 255, 255, 0.02);
+  --border-subtle:   rgba(74, 144, 226, 0.30);
+
+  /* Shadows */
+  --shadow-sm:          0 4px 20px rgba(0, 0, 0, 0.30);
+  --shadow-md:          0 16px 40px rgba(0, 0, 0, 0.50);
+  --shadow-lg:          0 20px 60px rgba(0, 0, 0, 0.40);
+  --shadow-blue-sm:     0 0 20px rgba(59, 130, 246, 0.30);
+  --shadow-blue-md:     0 0 30px rgba(59, 130, 246, 0.50);
+  --shadow-blue-card:   0 20px 40px rgba(59, 130, 246, 0.10);
+  --shadow-orange-card: 0 20px 40px rgba(249, 115, 22, 0.10);
+
+  /* Fonts */
+  --font-display: 'Cabinet Grotesk', 'Inter', sans-serif;
+  --font-body:    'Inter', -apple-system, sans-serif;
+  --font-mono:    'JetBrains Mono', 'Courier New', monospace;
+
+  /* Type scale */
   --text-xs:   clamp(0.75rem,  0.7rem  + 0.25vw, 0.875rem);
   --text-sm:   clamp(0.875rem, 0.8rem  + 0.35vw, 1rem);
   --text-base: clamp(1rem,     0.95rem + 0.25vw, 1.125rem);
@@ -27,11 +67,17 @@
   --text-xl:   clamp(1.5rem,   1.2rem  + 1.25vw, 2.25rem);
   --text-2xl:  clamp(2rem,     1.2rem  + 2.5vw,  3.5rem);
   --text-hero: clamp(3rem,     1rem    + 5vw,    5.5rem);
+
+  /* Spacing */
   --space-1:  0.25rem; --space-2: 0.5rem;  --space-3: 0.75rem;
   --space-4:  1rem;    --space-6: 1.5rem;  --space-8: 2rem;
   --space-10: 2.5rem;  --space-12: 3rem;   --space-16: 4rem;
   --space-20: 5rem;
+
+  /* Radius */
   --radius-sm: 6px; --radius-md: 10px; --radius-lg: 16px; --radius-xl: 24px;
+
+  /* Transition */
   --transition: 180ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -76,7 +122,6 @@ a { cursor: none; }
   }
   body { animation: none; }
 }
-
 @media (pointer: coarse) {
   body, a, button, [role="button"] { cursor: auto; }
   #cursor-dot, #cursor-ring { display: none !important; }
@@ -87,41 +132,29 @@ a { cursor: none; }
    ============================================================ */
 body::before {
   content: '';
-  position: fixed;
-  inset: 0;
-  z-index: 9998;
-  pointer-events: none;
-  opacity: 0.025;
+  position: fixed; inset: 0; z-index: 9998;
+  pointer-events: none; opacity: 0.025;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
-  background-repeat: repeat;
-  background-size: 180px 180px;
+  background-repeat: repeat; background-size: 180px 180px;
 }
 
 /* ============================================================
    CUSTOM CURSOR
-   FIX: aggiunto top:0; left:0 — senza, position:fixed non ha
-        un'ancora e transform:translate(x,y) del JS parte fuori viewport
    ============================================================ */
 #cursor-dot {
-  position: fixed;
-  top: 0; left: 0;
+  position: fixed; top: 0; left: 0;
   width: 6px; height: 6px;
   background: var(--accent-blue);
-  border-radius: 50%;
-  pointer-events: none;
-  z-index: 9999;
+  border-radius: 50%; pointer-events: none; z-index: 9999;
   margin-left: -3px; margin-top: -3px;
   transition: background 0.2s ease;
   will-change: transform;
 }
 #cursor-ring {
-  position: fixed;
-  top: 0; left: 0;
+  position: fixed; top: 0; left: 0;
   width: 32px; height: 32px;
-  border: 1.5px solid rgba(59, 130, 246, 0.5);
-  border-radius: 50%;
-  pointer-events: none;
-  z-index: 9999;
+  border: 1.5px solid var(--accent-blue-50);
+  border-radius: 50%; pointer-events: none; z-index: 9999;
   margin-left: -16px; margin-top: -16px;
   transition: width 0.25s ease, height 0.25s ease,
               border-color 0.25s ease, background 0.25s ease,
@@ -132,7 +165,7 @@ body::before {
   width: 48px; height: 48px;
   margin-left: -24px; margin-top: -24px;
   border-color: var(--accent-blue);
-  background: rgba(59, 130, 246, 0.06);
+  background: var(--accent-blue-06);
 }
 
 /* ============================================================
@@ -156,50 +189,33 @@ body::before {
 .glitch-once::before,
 .glitch-once::after {
   content: attr(data-text);
-  position: absolute;
-  inset: 0;
-  -webkit-background-clip: text;
-  background-clip: text;
+  position: absolute; inset: 0;
+  -webkit-background-clip: text; background-clip: text;
 }
 .glitch-once::before {
-  color: #3b82f6;
-  animation: glitch-clip-1 0.18s steps(1) 3;
-  left: -2px;
+  color: var(--accent-blue);
+  animation: glitch-clip-1 0.18s steps(1) 3; left: -2px;
 }
 .glitch-once::after {
-  color: #f97316;
-  animation: glitch-clip-2 0.18s steps(1) 3;
-  left: 2px;
+  color: var(--accent-orange);
+  animation: glitch-clip-2 0.18s steps(1) 3; left: 2px;
 }
 
 /* ============================================================
    SPOTLIGHT CARD
    ============================================================ */
-.glass-card,
-.skill-card,
-.project-card,
-.info-card {
-  position: relative;
-  overflow: hidden;
+.glass-card, .skill-card, .project-card, .info-card {
+  position: relative; overflow: hidden;
   transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
 }
-.glass-card::after,
-.skill-card::after,
-.project-card::after,
-.info-card::after {
+.glass-card::after, .skill-card::after, .project-card::after, .info-card::after {
   content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: radial-gradient(320px circle at var(--mx, -999px) var(--my, -999px), rgba(59,130,246,0.07), transparent 70%);
-  pointer-events: none;
-  transition: opacity 0.3s ease;
-  opacity: 0;
+  position: absolute; inset: 0; border-radius: inherit;
+  background: radial-gradient(320px circle at var(--mx, -999px) var(--my, -999px), var(--accent-blue-07), transparent 70%);
+  pointer-events: none; transition: opacity 0.3s ease; opacity: 0;
 }
-.glass-card:hover::after,
-.skill-card:hover::after,
-.project-card:hover::after,
-.info-card:hover::after { opacity: 1; }
+.glass-card:hover::after, .skill-card:hover::after,
+.project-card:hover::after, .info-card:hover::after { opacity: 1; }
 
 /* ============================================================
    TYPOGRAPHY
@@ -207,89 +223,58 @@ body::before {
 h1, .page-hero h1 {
   font-family: var(--font-display);
   font-size: var(--text-hero);
-  font-weight: 900;
-  line-height: 1.05;
-  letter-spacing: -0.02em;
-  color: var(--text-primary);
-  text-wrap: balance;
+  font-weight: 900; line-height: 1.05;
+  letter-spacing: -0.02em; color: var(--text-primary); text-wrap: balance;
 }
 .hero-title {
   font-family: var(--font-display);
   font-size: var(--text-hero);
-  font-weight: 900;
-  line-height: 1.05;
-  letter-spacing: -0.02em;
-  text-wrap: balance;
-  background: linear-gradient(135deg, #fff 30%, var(--accent-blue));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  font-weight: 900; line-height: 1.05;
+  letter-spacing: -0.02em; text-wrap: balance;
+  background: linear-gradient(135deg, var(--text-white) 30%, var(--accent-blue));
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
 }
 .gradient-text {
-  background: linear-gradient(135deg, #fff 30%, var(--accent-blue));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  background: linear-gradient(135deg, var(--text-white) 30%, var(--accent-blue));
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
 }
 h2, .section-title {
   font-family: var(--font-display);
-  font-size: var(--text-2xl);
-  font-weight: 800;
-  line-height: 1.15;
-  letter-spacing: -0.015em;
-  color: var(--text-primary);
-  margin-bottom: var(--space-8);
-  text-wrap: balance;
+  font-size: var(--text-2xl); font-weight: 800;
+  line-height: 1.15; letter-spacing: -0.015em;
+  color: var(--text-primary); margin-bottom: var(--space-8); text-wrap: balance;
 }
 h3 {
   font-family: var(--font-body);
-  font-size: var(--text-xl);
-  font-weight: 700;
-  line-height: 1.25;
-  letter-spacing: -0.01em;
-  color: var(--text-primary);
-  margin-bottom: var(--space-4);
+  font-size: var(--text-xl); font-weight: 700;
+  line-height: 1.25; letter-spacing: -0.01em;
+  color: var(--text-primary); margin-bottom: var(--space-4);
 }
 h4 {
   font-family: var(--font-body);
-  font-size: var(--text-lg);
-  font-weight: 600;
-  line-height: 1.3;
-  color: var(--text-primary);
-  margin-bottom: var(--space-3);
+  font-size: var(--text-lg); font-weight: 600;
+  line-height: 1.3; color: var(--text-primary); margin-bottom: var(--space-3);
 }
 p {
   font-family: var(--font-body);
-  font-size: var(--text-base);
-  line-height: 1.8;
-  color: var(--text-secondary);
-  max-width: 72ch;
-  text-wrap: pretty;
+  font-size: var(--text-base); line-height: 1.8;
+  color: var(--text-secondary); max-width: 72ch; text-wrap: pretty;
 }
 .section-label, .eyebrow {
   font-family: var(--font-body);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-  color: var(--accent-orange);
-  margin-bottom: var(--space-3);
-  display: block;
+  font-size: var(--text-xs); font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.15em;
+  color: var(--accent-orange); margin-bottom: var(--space-3); display: block;
 }
 .lead, .hero-subtitle, .page-hero p {
-  font-size: var(--text-lg);
-  line-height: 1.7;
-  color: var(--text-secondary);
-  font-weight: 400;
-  max-width: 60ch;
+  font-size: var(--text-lg); line-height: 1.7;
+  color: var(--text-secondary); font-weight: 400; max-width: 60ch;
 }
 .text-sm, small { font-size: var(--text-sm); color: var(--text-muted); line-height: 1.5; }
 code, kbd, .mono {
-  font-family: var(--font-mono);
-  font-size: 0.9em;
-  background: rgba(255,255,255,0.05);
-  padding: 0.15em 0.45em;
-  border-radius: var(--radius-sm);
+  font-family: var(--font-mono); font-size: 0.9em;
+  background: var(--border-surface);
+  padding: 0.15em 0.45em; border-radius: var(--radius-sm);
   color: var(--accent-orange);
 }
 
@@ -306,35 +291,30 @@ code, kbd, .mono {
 #site-header {
   position: fixed; top: 0; width: 100%;
   padding: var(--space-4) 5%;
-  background: rgba(10, 10, 12, 0.92);
-  backdrop-filter: blur(15px);
-  -webkit-backdrop-filter: blur(15px);
-  z-index: 2000;
-  border-bottom: 1px solid var(--glass-border);
+  background: var(--bg-nav);
+  backdrop-filter: blur(15px); -webkit-backdrop-filter: blur(15px);
+  z-index: 2000; border-bottom: 1px solid var(--glass-border);
 }
 #site-header nav ul {
   display: flex; justify-content: flex-end;
   gap: 2.5rem; list-style: none; align-items: center;
 }
 #site-header nav a {
-  color: var(--text-secondary);
-  text-decoration: none;
-  font-size: var(--text-xs);
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
+  color: var(--text-secondary); text-decoration: none;
+  font-size: var(--text-xs); font-weight: 500;
+  text-transform: uppercase; letter-spacing: 1.5px;
   transition: color var(--transition);
 }
 #site-header nav a:hover, .active-link { color: var(--accent-blue) !important; }
 .dropdown { position: relative; }
 .dropdown-content {
   position: absolute; top: 100%; right: 0;
-  background: #0f0f14;
+  background: var(--bg-dropdown);
   border: 1px solid var(--glass-border);
   min-width: 200px; display: none;
   border-radius: var(--radius-md);
   padding: var(--space-2) 0; z-index: 3000;
-  box-shadow: 0 16px 40px rgba(0,0,0,0.5);
+  box-shadow: var(--shadow-md);
 }
 .dropdown:hover .dropdown-content { display: block; }
 .dropdown-content a {
@@ -346,50 +326,44 @@ code, kbd, .mono {
   transition: color var(--transition), background var(--transition);
 }
 .dropdown-content a:hover {
-  color: #fff !important;
-  background: rgba(59,130,246,0.1) !important;
+  color: var(--text-white) !important;
+  background: var(--accent-blue-10) !important;
 }
 
 /* ============================================================
    HERO
    ============================================================ */
 .hero {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  padding: 10rem 5% 4rem;
+  min-height: 100vh; display: flex;
+  align-items: center; padding: 10rem 5% 4rem;
 }
 .hero-inner {
   max-width: 1300px; margin: 0 auto; width: 100%;
-  display: grid;
-  grid-template-columns: 1.2fr 1fr;
-  gap: var(--space-16);
-  align-items: center;
+  display: grid; grid-template-columns: 1.2fr 1fr;
+  gap: var(--space-16); align-items: center;
 }
 .hero-text { display: flex; flex-direction: column; gap: var(--space-6); }
 .hero-badge {
   display: inline-flex; align-items: center; gap: var(--space-2);
   padding: var(--space-2) var(--space-4);
-  background: rgba(16,185,129,0.1);
-  border: 1px solid rgba(16,185,129,0.2);
+  background: var(--accent-green-10);
+  border: 1px solid var(--accent-green-20);
   border-radius: 20px;
   font-size: var(--text-xs); font-weight: 500;
-  color: var(--accent-green);
-  width: fit-content;
+  color: var(--accent-green); width: fit-content;
   text-transform: uppercase; letter-spacing: 0.5px;
 }
 .badge-dot {
   width: 6px; height: 6px;
   background: var(--accent-green);
-  border-radius: 50%;
-  animation: pulse 2s ease infinite;
+  border-radius: 50%; animation: pulse 2s ease infinite;
 }
 @keyframes pulse { 0%,100% { opacity:1; } 50% { opacity:0.5; } }
 .hero-meta { display: flex; gap: var(--space-3); flex-wrap: wrap; }
 .meta-tag {
   padding: var(--space-1) var(--space-3);
-  background: rgba(59,130,246,0.1);
-  border: 1px solid rgba(59,130,246,0.2);
+  background: var(--accent-blue-10);
+  border: 1px solid var(--accent-blue-20);
   border-radius: var(--radius-sm);
   font-size: var(--text-xs); color: var(--accent-blue); font-weight: 500;
 }
@@ -402,23 +376,17 @@ code, kbd, .mono {
   display: inline-block;
   padding: var(--space-3) var(--space-8);
   border-radius: var(--radius-md);
-  font-family: var(--font-body);
-  font-size: var(--text-sm);
-  font-weight: 600;
+  font-family: var(--font-body); font-size: var(--text-sm); font-weight: 600;
   text-decoration: none;
   transition: transform var(--transition), box-shadow var(--transition),
-              background var(--transition), border-color var(--transition),
-              color var(--transition);
+              background var(--transition), border-color var(--transition), color var(--transition);
 }
 .btn-primary {
   background: var(--accent-blue);
-  color: #fff;
-  box-shadow: 0 0 20px rgba(59,130,246,0.3);
+  color: var(--text-white);
+  box-shadow: var(--shadow-blue-sm);
 }
-.btn-primary:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 0 30px rgba(59,130,246,0.5);
-}
+.btn-primary:hover { transform: translateY(-2px); box-shadow: var(--shadow-blue-md); }
 .btn-ghost {
   background: transparent;
   border: 1px solid var(--glass-border);
@@ -430,10 +398,7 @@ code, kbd, .mono {
   border: 1px solid var(--accent-blue);
   color: var(--accent-blue);
 }
-.btn-secondary:hover {
-  background: rgba(59,130,246,0.1);
-  transform: translateY(-2px);
-}
+.btn-secondary:hover { background: var(--accent-blue-10); transform: translateY(-2px); }
 
 /* ============================================================
    TERMINAL
@@ -442,19 +407,18 @@ code, kbd, .mono {
   background: var(--bg-card);
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
-  overflow: hidden;
-  box-shadow: 0 20px 60px rgba(0,0,0,0.4);
+  overflow: hidden; box-shadow: var(--shadow-lg);
 }
 .terminal-header {
   padding: var(--space-3) var(--space-4);
-  background: rgba(0,0,0,0.3);
+  background: var(--bg-terminal-hdr);
   border-bottom: 1px solid var(--glass-border);
   display: flex; align-items: center; gap: var(--space-2);
 }
 .t-dot { width: 12px; height: 12px; border-radius: 50%; }
-.t-dot.red    { background: #ef4444; }
-.t-dot.yellow { background: #f59e0b; }
-.t-dot.green  { background: #10b981; }
+.t-dot.red    { background: var(--accent-red); }
+.t-dot.yellow { background: var(--accent-yellow); }
+.t-dot.green  { background: var(--accent-green); }
 .t-title { color: var(--text-muted); font-size: var(--text-xs); margin-left: auto; font-family: var(--font-mono); }
 .terminal-body { padding: var(--space-6); font-family: var(--font-mono); font-size: var(--text-sm); }
 .t-line   { margin-bottom: var(--space-2); color: var(--text-secondary); }
@@ -469,8 +433,7 @@ code, kbd, .mono {
    ============================================================ */
 .section-divider {
   width: 100%; height: 1px;
-  background: var(--glass-border);
-  margin: var(--space-12) 0;
+  background: var(--glass-border); margin: var(--space-12) 0;
 }
 
 /* ============================================================
@@ -479,20 +442,18 @@ code, kbd, .mono {
 .skills-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: var(--space-8);
-  max-width: 1200px; margin: 0 auto;
+  gap: var(--space-8); max-width: 1200px; margin: 0 auto;
 }
 .skill-card {
   background: var(--bg-card);
   border: 1px solid var(--glass-border);
-  border-radius: var(--radius-lg);
-  padding: var(--space-10);
+  border-radius: var(--radius-lg); padding: var(--space-10);
   transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
 }
 .skill-card:hover {
   transform: translateY(-5px);
   border-color: var(--accent-blue);
-  box-shadow: 0 20px 40px rgba(59,130,246,0.1);
+  box-shadow: var(--shadow-blue-card);
 }
 .skill-icon { font-size: 2.5rem; margin-bottom: var(--space-6); }
 .skill-card h3 { font-size: var(--text-lg); margin-bottom: var(--space-4); font-weight: 600; }
@@ -505,21 +466,19 @@ code, kbd, .mono {
 .projects-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: var(--space-8);
-  max-width: 1200px; margin: 0 auto;
+  gap: var(--space-8); max-width: 1200px; margin: 0 auto;
 }
 .project-card {
   background: var(--bg-card);
   border: 1px solid var(--glass-border);
-  border-radius: var(--radius-lg);
-  padding: var(--space-8);
+  border-radius: var(--radius-lg); padding: var(--space-8);
   text-decoration: none; display: block;
   transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
 }
 .project-card:hover {
   transform: translateY(-5px);
   border-color: var(--accent-orange);
-  box-shadow: 0 20px 40px rgba(249,115,22,0.1);
+  box-shadow: var(--shadow-orange-card);
 }
 .project-header {
   display: flex; justify-content: space-between; align-items: center;
@@ -530,31 +489,21 @@ code, kbd, .mono {
 .project-card:hover .project-arrow { transform: translateX(5px); color: var(--accent-orange); }
 .project-card h4 { font-size: var(--text-lg); margin-bottom: var(--space-3); color: var(--text-primary); font-weight: 600; }
 .project-card p  { color: var(--text-secondary); font-size: var(--text-sm); line-height: 1.7; }
-.glass-card { backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); background: rgba(22,22,26,0.6); }
+.glass-card { backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px); background: var(--bg-card); }
 
 /* ============================================================
    REVEAL ANIMATIONS
    ============================================================ */
-.reveal-on-scroll,
-.feature-card {
-  opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 0.8s cubic-bezier(0.16,1,0.3,1),
-              transform 0.8s cubic-bezier(0.16,1,0.3,1);
+.reveal-on-scroll, .feature-card {
+  opacity: 0; transform: translateY(20px);
+  transition: opacity 0.8s cubic-bezier(0.16,1,0.3,1), transform 0.8s cubic-bezier(0.16,1,0.3,1);
 }
 .revealed {
-  opacity: 1 !important;
-  transform: translateY(0) !important;
+  opacity: 1 !important; transform: translateY(0) !important;
   clip-path: inset(0% 0% 0% 0%) !important;
 }
-.hero,
-.hero-text,
-.hero-title,
-.hero-subtitle,
-.hero-buttons,
-.hero-terminal {
-  opacity: 1 !important;
-  transform: none !important;
+.hero, .hero-text, .hero-title, .hero-subtitle, .hero-buttons, .hero-terminal {
+  opacity: 1 !important; transform: none !important;
 }
 
 /* ============================================================
@@ -562,20 +511,30 @@ code, kbd, .mono {
    ============================================================ */
 footer, #site-footer {
   padding: var(--space-12) 5%;
-  text-align: center;
   border-top: 1px solid var(--glass-border);
   color: var(--text-muted);
   font-size: var(--text-xs);
 }
+.footer-inner {
+  max-width: 1200px; margin: 0 auto;
+  display: flex; justify-content: space-between; align-items: center;
+  flex-wrap: wrap; gap: var(--space-4);
+}
+.footer-links { display: flex; gap: var(--space-6); }
+.footer-links a {
+  color: var(--text-muted); text-decoration: none;
+  font-size: var(--text-xs); letter-spacing: 0.5px;
+  transition: color var(--transition);
+}
+.footer-links a:hover { color: var(--accent-blue); }
+#visit-count { color: var(--text-muted); font-size: var(--text-xs); }
 
 /* ============================================================
    UTILITIES
    ============================================================ */
 .accent-link {
-  color: var(--accent-blue);
-  text-decoration: none;
-  border-bottom: 1px solid transparent;
-  transition: border-color var(--transition);
+  color: var(--accent-blue); text-decoration: none;
+  border-bottom: 1px solid transparent; transition: border-color var(--transition);
 }
 .accent-link:hover { border-color: var(--accent-blue); }
 
@@ -586,45 +545,36 @@ footer, #site-footer {
 .page-hero { padding: var(--space-20) 5% var(--space-16); max-width: 1200px; margin: 0 auto; }
 .page-hero h1 {
   font-family: var(--font-display);
-  font-size: var(--text-2xl);
-  font-weight: 900;
-  line-height: 1.1;
-  letter-spacing: -0.02em;
-  margin-bottom: var(--space-6);
+  font-size: var(--text-2xl); font-weight: 900;
+  line-height: 1.1; letter-spacing: -0.02em; margin-bottom: var(--space-6);
 }
 .meta-pill {
   padding: var(--space-2) var(--space-4);
-  background: rgba(74,144,226,0.1);
-  border: 1px solid rgba(74,144,226,0.3);
+  background: var(--accent-blue-10);
+  border: 1px solid var(--border-subtle);
   border-radius: 20px;
   font-size: var(--text-sm); color: var(--accent-blue); font-weight: 500;
 }
 .content-panel h2 {
   font-family: var(--font-display);
   font-size: var(--text-xl); font-weight: 800;
-  letter-spacing: -0.01em;
-  margin-bottom: var(--space-6);
-  color: var(--text-primary);
+  letter-spacing: -0.01em; margin-bottom: var(--space-6); color: var(--text-primary);
 }
 .content-panel h3 { font-size: var(--text-lg); margin: var(--space-8) 0 var(--space-4); color: var(--text-primary); font-weight: 600; }
 .content-panel p  { font-size: var(--text-base); line-height: 1.8; color: var(--text-secondary); margin-bottom: var(--space-6); }
 .content-panel ul { margin: var(--space-6) 0; padding-left: 0; list-style: none; }
 .content-panel li {
   padding: var(--space-3) 0 var(--space-3) var(--space-6);
-  position: relative;
-  font-size: var(--text-base); line-height: 1.7;
-  color: var(--text-secondary);
+  position: relative; font-size: var(--text-base); line-height: 1.7; color: var(--text-secondary);
 }
 .content-panel li::before {
-  content: "→";
-  position: absolute; left: 0;
+  content: "\2192"; position: absolute; left: 0;
   color: var(--accent-blue); font-weight: bold;
 }
 .info-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: var(--space-8); }
 .info-card {
-  background: rgba(255,255,255,0.02);
-  padding: var(--space-8);
-  border-radius: var(--radius-lg);
+  background: var(--border-surface);
+  padding: var(--space-8); border-radius: var(--radius-lg);
   border: 1px solid var(--glass-border);
 }
 .info-card h2 { font-size: var(--text-lg); margin-bottom: var(--space-3); color: var(--text-primary); }
@@ -636,9 +586,8 @@ footer, #site-footer {
 .contact-method a:hover { color: var(--accent-blue); }
 .embed-grid { display: grid; gap: var(--space-8); }
 .embed-card {
-  background: rgba(255,255,255,0.02);
-  padding: var(--space-8);
-  border-radius: var(--radius-lg);
+  background: var(--border-surface);
+  padding: var(--space-8); border-radius: var(--radius-lg);
   border: 1px solid var(--glass-border);
 }
 .embed-card h2 { font-size: var(--text-lg); margin-bottom: var(--space-4); }
@@ -651,12 +600,10 @@ footer, #site-footer {
 #gallery img {
   width: 100%; max-width: 900px; max-height: 350px;
   object-fit: contain; margin: 0 auto; display: block;
-  border-radius: var(--radius-md);
-  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+  border-radius: var(--radius-md); box-shadow: var(--shadow-sm);
 }
 .gallery-container, .slider-container {
-  display: flex; justify-content: center; align-items: center;
-  padding: var(--space-4) 0;
+  display: flex; justify-content: center; align-items: center; padding: var(--space-4) 0;
 }
 .slideshow-container { width: 500px; height: 350px; overflow: hidden; }
 .slideshow img { width: 400px; height: 350px; object-fit: cover; border-radius: var(--radius-md); }
@@ -664,9 +611,7 @@ footer, #site-footer {
 /* ============================================================
    RESPONSIVE
    ============================================================ */
-@media (max-width: 900px) {
-  .hero-inner { grid-template-columns: 1fr; gap: var(--space-12); }
-}
+@media (max-width: 900px) { .hero-inner { grid-template-columns: 1fr; gap: var(--space-12); } }
 @media (max-width: 768px) {
   .hero { padding: 8rem 5% 3rem; }
   .page-hero h1       { font-size: var(--text-xl); }
@@ -679,4 +624,6 @@ footer, #site-footer {
   .skills-grid        { grid-template-columns: 1fr; }
   .projects-grid      { grid-template-columns: 1fr; }
   #site-header nav ul { gap: 1.5rem; }
+  .footer-inner       { flex-direction: column; text-align: center; }
+  .footer-links       { justify-content: center; }
 }


### PR DESCRIPTION
…footer, meta descriptions

- Remove template-components.js from all pages (stub kept for safety)
- menu.js: renamed nav labels, professional footer with links, single source of truth
- styles.css v6: all rgba/hex hardcoded values replaced with CSS custom properties (--accent-blue-10, --shadow-md, --bg-nav, --bg-dropdown, etc.)
- footer: semantic layout with .footer-inner, copyright + LinkedIn/GitHub/Contact links
- index.html, contact.html, strava.html, hospital, bike: added meta description + og tags
- contact.html: corrected copy (healthcare consultant, not cybersecurity)